### PR TITLE
修复 #20

### DIFF
--- a/src/main/java/dev/sefiraat/netheopoiesis/implementation/tools/MixingQuartz.java
+++ b/src/main/java/dev/sefiraat/netheopoiesis/implementation/tools/MixingQuartz.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 public class MixingQuartz extends LimitedUseItem {
 
     private static final NamespacedKey KEY = Keys.newKey("uses");
-    private static final Pattern LORE_FLAVOUR = Pattern.compile(Theme.CLICK_INFO + "风味值: [0-9]+");
+    private static final Pattern LORE_FLAVOUR = Pattern.compile(Theme.CLICK_INFO.asTitle("风味值", "[0-9]+").substring(0, 2) + Theme.CLICK_INFO.asTitle("风味值", "[0-9]+").substring(2).toUpperCase());
 
     public MixingQuartz(ItemGroup group,
                         SlimefunItemStack item,


### PR DESCRIPTION
close #20.

不知为何，下界丸子在初始化时，风味值的颜色代码被大写了（除了第一个 x）。

所以把正则表达式的部分颜色代码也大写化，即可解决问题。

经自机测试，可以修复漏洞。